### PR TITLE
Update ibrowse.app.src

### DIFF
--- a/src/ibrowse.app.src
+++ b/src/ibrowse.app.src
@@ -3,7 +3,7 @@
          {vsn, "4.4.2"},
          {registered, [ibrowse_sup, ibrowse]},
          {applications, [kernel,stdlib,ssl]},
-         {included_applications, []},
+         {optional_applications, [ssl]},
 	 {env, []},
 	 {mod, {ibrowse_app, []}},
          {maintainers, ["Chandrashekhar Mullaparthi"]},


### PR DESCRIPTION
SSL is not always started when ibrowse is used (e.g. in riak_test).  However, without SSL in applications then dialyzer will complain. So SSL needs to be an optional application.